### PR TITLE
Remove `pre-wrap` to minimize excessive spacing

### DIFF
--- a/mockup/css/style.css
+++ b/mockup/css/style.css
@@ -932,13 +932,13 @@ a.nav_item_sidebar--sub {
   top: 8px;
 }
 .post_item_text {
-  white-space: pre-wrap;
+  word-wrap: break-word;
   font-size: 14px;
   line-height: 18px;
   margin: 6px 0px;
 }
 .post_item_text p {
-  margin: 0px;
+  margin: 0 0 8px;
   line-height: 20px;
   font-size: 14px;
 }


### PR DESCRIPTION
This should fix #3.

I am not sure which branch should I be submitting this change to, correct me if I'm wrong and I'll create another PR or something. :grimacing: 

On this branch:
- Remove `white-space: pre-wrap` to get rid of the excessive spacing
- Add `word-wrap` to enforce wrapping
- Add margin on `p` tags so paragraphs can be visualized

**Before**

![image](https://cloud.githubusercontent.com/assets/1153134/5694650/07a97904-99ac-11e4-8c28-adeff4623ba3.png)

**After**

![image](https://cloud.githubusercontent.com/assets/1153134/5694649/feb8ff4a-99ab-11e4-8c54-9631cd6de04f.png)

cc @audreyt 
